### PR TITLE
CONJ-4597: Update docs to describe using Host as SB Conjur identity

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -121,7 +121,7 @@ When creating the dedicated Conjur policy for PCF, consider the following:
 
 #### To create a dedicated Conjur policy for PCF:
 
-##### Step 1: Create a policy using the following example as a guide.  Save the policy as a `.yml` file.
+##### Step 1: Create a policy using the following example as a guide.  Save the policy as a `.yml` file (we use `your-pcf-policy-file.yml` below).
 
 
    ```

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -19,7 +19,7 @@ The CyberArk Conjur Service Broker for PCF installs a buildpack that includes th
 
 CyberArk Conjur Service Broker for PCF includes the following key features:
 
-* After you configure the tile and bind applications to service instances, your PCF applications, containers, and microservices assume a Host identity in Conjur. This identity enables secure access to secret values and policy grants stored in Conjur.
+* After you configure the tile and bind applications to service instances, your PCF applications, containers, and microservices assume a host identity in Conjur. This identity enables secure access to secret values and policy grants stored in Conjur.
 * If you have an existing Conjur appliance, you can grant privileges to PCF applications to access the existing Conjur secrets via Conjur policy.
 * Conjur integrates easily into the PCF environment and the PCF developer workflow.
 * The strong authentication model provided by Conjur is available to PCF applications.
@@ -77,23 +77,23 @@ CyberArk Conjur Service Broker for PCF has the following requirements:
 + To configure the PCF tile, you must know the following information about your Conjur appliance:
   * Conjur Account, which is specified when the Conjur appliance is created and configured. For hosted Conjur, the account is usually an email address that you specify on the web form.
   * URL to the Conjur appliance.
-  * Valid Conjur identity for a Host that has `update` and `create` privileges on PCF-related Conjur Policy.   The Service Broker uses these credentials to add and remove Host identities as you deploy and remove PCF applications. See [Recommendations](#recommendations).
+  * Valid Conjur identity for a Host that has `update` and `create` privileges on PCF-related Conjur policy.   The Service Broker uses these credentials to add and remove host identities as you deploy and remove PCF applications. See [Recommendations](#recommendations).
   * Conjur API Key associated with the Host.
-  * PCF Conjur Policy Namespace (optional). For production Conjur appliances, CyberArk strongly recommends a dedicated PCF Policy; otherwise, the Conjur root Policy is the default.  See [Recommendations](#recommendations) for more information.
+  * PCF Conjur Policy Namespace (optional). For production Conjur appliances, CyberArk strongly recommends a Conjur policy dedicated to PCF; otherwise, the Conjur root policy is the default.  See [Recommendations](#recommendations) for more information.
   * Conjur version. Either 4 for Enterprise Conjur or 5 for Open Source Conjur.
 
 Enterprise Conjur (v4) has the following additional requirements:
 
   *  The tile installation requires a copy and paste of the x509 certificate that was created when Conjur was initiated. The certificate is stored in a `.pem` file that was created by the `conjur init` command. The default path is `/conjur_install_directory/conjur-account.pem`.
 
-  *  The Service Broker requires a Conjur Host Factory to use when adding Host identities. The examples below in [Recommendations](#recommendations) include Host Factory definitions. If a Host Factory is not properly defined, a health check near the end of tile installation reports the condition, and the tile installation fails.
+  *  The Service Broker requires a Conjur Host Factory to use when adding host identities. The examples below in [Recommendations](#recommendations) include host factory definitions. If a host factory is not properly defined, a health check near the end of tile installation reports the condition, and the tile installation fails.
 
 
 ## <a id="recommendations"></a>Recommendations
 
-### Declare a Dedicated PCF Policy
+### Create a Dedicated Conjur Policy for PCF
 
- CyberArk strongly recommends that you create a Conjur Policy dedicated to PCF.  Create this Policy before installing the PCF tile.
+ CyberArk strongly recommends that you create a Conjur policy dedicated to PCF.  Create this policy before installing the PCF tile.
 
   The syntax for defining a Conjur Policy with ID `my-pcf` is as follows:
 
@@ -102,28 +102,28 @@ Enterprise Conjur (v4) has the following additional requirements:
   id: my-pcf
 ```
 
-  This can be loaded into the root Policy or any other Conjur Policy you would like. Host identities for PCF-deployed applications
-  will be loaded into the `my-pcf` Conjur Policy when the applications are bound to a Conjur service instance.
+  This can be loaded into the root Policy or any other Conjur policy you would like. Host identities for PCF-deployed applications
+  will be loaded into the `my-pcf` Conjur policy when the applications are bound to a Conjur service instance.
 
-A dedicated PCF Policy supports least privilege principles in the following ways:
+A dedicated Conjur policy for PCF supports least privilege principles in the following ways:
 
-  * The secrets, Host identities, and access control policies for your PCF-deployed applications are isolated from other resources stored in Conjur.
-  * Conjur access privileges required by the Service Broker, DevOps teams, and your applications can be limited in scope to the PCF Policy.
-  * You can give a limited set of Conjur users access to PCF, with even finer-grained permissions possible within the PCF Policy itself.
-  * For Conjur Enterprise (v4), you can define the Host Factory layer in the PCF Policy, rather than in the root Policy.
+  * The secrets, host identities, and access control policies for your PCF-deployed applications are isolated from other resources stored in Conjur.
+  * Conjur access privileges required by the Service Broker, DevOps teams, and your applications can be limited in scope to the dedicated Conjur policy for PCF.
+  * You can give a limited set of Conjur users access to the dedicated Conjur policy for PCF, with even finer-grained permissions possible within the PCF policy itself.
+  * For Conjur Enterprise (v4), you can define the Host Factory layer in the dedicated Conjur policy for PCF, rather than in the root policy.
 
-When creating the Conjur Policy for PCF, consider the following:
+When creating the dedicated Conjur policy for PCF, consider the following:
 
- * The Service Broker requires `create` and `update` privileges on the Policy to add and remove Host identities. Members of the Group that owns the Policy have those privileges.
+ * The Service Broker requires `create` and `update` privileges on the policy to add and remove host identities. Members of the group that owns the policy have those privileges.
  * PCF DevOps personnel need access to Conjur to declare application secrets and grant privileges to the applications to access those secrets.
  * For Conjur Enterprise (v4), a Host Factory is required. Both the ID of the Layer and the Host Factory must use the syntax `namespace-apps`, where `apps` is a constant. For example, `pcf-apps` is used in the policy example shown below.
 
 
-To create a dedicated PCF Policy:
+To create a dedicated Conjur policy for PCF:
 
 Step 1: Create a policy using the following example as a guide.  Save the policy as a `.yml` file.
 
- Example policy file declaring a dedicated PCF Policy:
+ Example policy file that creates a dedicated Conjur policy `pcf` for PCF:
 
    ```
   - !host
@@ -151,13 +151,13 @@ Step 1: Create a policy using the following example as a guide.  Save the policy
         layers: [ !layer pcf-apps ]
    ```
 
-   This policy file creates a Host identity `host/pcf-service-broker` that can be used as the `CONJUR_AUTHN_LOGIN` role in the Tile configuration.
+   This policy file creates a `host/pcf-service-broker` Host that can be used as the `CONJUR_AUTHN_LOGIN` role in the Tile configuration.
    The `pcf-service-broker` Host is a member of the `pcf-admin-group` Group, which owns the `pcf` Policy, so it has `create` and `update` privileges on that Policy as required.
    The `pcf` Policy has a `pcf-apps` Layer and corresponding Host-Factory; if using Conjur version 4, application Hosts will be added to the `pcf-apps` Layer via the `pcf-apps` Host Factory when the application is bound to a Conjur service instance.
    Additional policies for individual applications can be appended to this file or loaded in separate `.yml` files as needed.
 
 
-Step 2. Load the policy into Conjur as follows (in this example, we are loading it into the root Policy):
+Step 2. Load the policy into Conjur as follows (in this example, we are loading it into the root policy):
 
    For Conjur Enterprise (v4):
 
@@ -172,7 +172,7 @@ Step 2. Load the policy into Conjur as follows (in this example, we are loading 
    ```
 
 Step 3. In the CyberArk Conjur Service Broker for PCF tile configuration:
-  *  For **PCF Conjur Policy Namespace**, use the Policy ID (`pcf` in the above example)
+  *  For **PCF Conjur Policy Namespace**, use the full path to the dedicated Conjur policy for PCF (`pcf` in the above example)
   *  For **Conjur Login**, use a Conjur Host who is a member of the Group that owns the PCF Policy (`host/pcf-service-broker` in the example above).
   *  For **Conjur API Key**, use that Host's API key. The admin who created the role can retrieve the value with this command:
 
@@ -182,17 +182,17 @@ Step 3. In the CyberArk Conjur Service Broker for PCF tile configuration:
 
 ### Use the Default Root Policy
 
-If you decide to use the default root Policy for PCF, consider the following:
+If you decide to use leave the **PCF Conjur Policy Namespace** blank in the tile configuration (that is, you choose to use the default root policy), consider the following:
 
 * You are not following least privilege best practice.
 
-* The admin Host that you provide on tile installation must have `create` and `update` privileges on the root Policy, which means that it will be privileged to edit _any Policy in your Conjur installation_.
+* The Conjur host identity that you provide on tile installation must have `create` and `update` privileges on the root policy, which means that it will be privileged to edit _any policy in your Conjur installation_.
 
-* The Service Broker will add Host identities for your PCF applications to the root Policy.
+* The Service Broker will add host identities for your PCF applications to the root policy.
 
-* The PCF DevOps teams will be altering policy files in the root Policy.
+* The PCF DevOps teams will be altering policy files in the root policy.
 
-* For integration with Conjur v4, a Host Factory named `apps` is required.  Add the following layer declaration to the root Policy:
+* For integration with Conjur v4, a Host Factory named `apps` is required.  Add the following layer declaration to the root policy:
 
 
  ```

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -95,15 +95,15 @@ Enterprise Conjur (v4) has the following additional requirements:
 
  CyberArk strongly recommends that you create a Conjur policy dedicated to PCF.  Create this policy before installing the PCF tile.
 
-  The syntax for defining a Conjur Policy with ID `my-pcf` is as follows:
+  The syntax for defining a Conjur Policy with ID `pcf` is as follows:
 
 ```
 - !policy
-  id: my-pcf
+  id: pcf
 ```
 
   This can be loaded into the root Policy or any other Conjur policy you would like. Host identities for PCF-deployed applications
-  will be loaded into the `my-pcf` Conjur policy when the applications are bound to a Conjur service instance.
+  will be loaded into the `pcf` Conjur policy when the applications are bound to a Conjur service instance.
 
 A dedicated Conjur policy for PCF supports least privilege principles in the following ways:
 

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -5,12 +5,12 @@ owner: Partners
 
 <p class='note warning'><strong>WARNING:</strong> The CyberArk Conjur Service Broker for PCF tile is currently in beta and is intended for evaluation and test purposes only. Do not use this product in a PCF production environment.</p>
 
-This documentation describes the CyberArk Conjur Service Broker for Pivotal Cloud Foundry (PCF). This service broker provides Conjur machine identity management and authentication, policy-based authorization, and other Conjur services to your PCF applications and microservices.
+This documentation describes the CyberArk Conjur Service Broker for Pivotal Cloud Foundry (PCF). This Service Broker provides Conjur machine identity management and authentication, policy-based authorization, and other Conjur services to your PCF applications and microservices.
 
 
 ## <a id='overview'></a>Overview
 
-The CyberArk Conjur Service Broker for PCF registers a service broker with PCF and exposes its service plans on the Marketplace. Developers can then create applications that access a Conjur appliance. The service broker provides the interface between your PCF applications and a Conjur appliance.
+The CyberArk Conjur Service Broker for PCF registers a service broker with PCF and exposes its service plans on the Marketplace. Developers can then create applications that access a Conjur appliance. The Service Broker provides the interface between your PCF applications and a Conjur appliance.
 
 The CyberArk Conjur Service Broker for PCF installs a buildpack that includes the Conjur Summon tool. Summon fetches secrets from Conjur using the binding ID from your PCF service as the unique application identity.
 
@@ -19,8 +19,8 @@ The CyberArk Conjur Service Broker for PCF installs a buildpack that includes th
 
 CyberArk Conjur Service Broker for PCF includes the following key features:
 
-* After you configure the tile and bind applications to service instances, your PCF applications, containers, and microservices assume a host identity in Conjur. This identity enables secure access to secret values and policy grants stored in Conjur.
-* If you have an existing Conjur appliance, Conjur policy can grant privileges to the PCF applications to access the existing Conjur secrets.
+* After you configure the tile and bind applications to service instances, your PCF applications, containers, and microservices assume a Host identity in Conjur. This identity enables secure access to secret values and policy grants stored in Conjur.
+* If you have an existing Conjur appliance, you can grant privileges to PCF applications to access the existing Conjur secrets via Conjur policy.
 * Conjur integrates easily into the PCF environment and the PCF developer workflow.
 * The strong authentication model provided by Conjur is available to PCF applications.
 * The Conjur role-based policy model for authorizations applies to applications running in PCF.
@@ -77,62 +77,64 @@ CyberArk Conjur Service Broker for PCF has the following requirements:
 + To configure the PCF tile, you must know the following information about your Conjur appliance:
   * Conjur Account, which is specified when the Conjur appliance is created and configured. For hosted Conjur, the account is usually an email address that you specify on the web form.
   * URL to the Conjur appliance.
-  * Valid Conjur user name for a user that has update and create privileges on PCF-related Conjur policy.   The Service Broker uses these credentials to add and remove host identities as you deploy and remove PCF applications. See [Recommendations](#recommendations).
-  *  Conjur API Key associated with the user name.
-  *  PCF Conjur Policy Namespace (optional). For production Conjur appliances, CyberArk strongly recommends  a dedicated PCF namespace;  otherwise, the Conjur root policy is the default.  See [Recommendations](#recommendations) for more information.
-  *  Conjur version. Either 4 for Enterprise Conjur or 5 for Open Source Conjur.
+  * Valid Conjur identity for a Host that has `update` and `create` privileges on PCF-related Conjur Policy.   The Service Broker uses these credentials to add and remove Host identities as you deploy and remove PCF applications. See [Recommendations](#recommendations).
+  * Conjur API Key associated with the Host.
+  * PCF Conjur Policy Namespace (optional). For production Conjur appliances, CyberArk strongly recommends a dedicated PCF Policy; otherwise, the Conjur root Policy is the default.  See [Recommendations](#recommendations) for more information.
+  * Conjur version. Either 4 for Enterprise Conjur or 5 for Open Source Conjur.
 
 Enterprise Conjur (v4) has the following additional requirements:
 
   *  The tile installation requires a copy and paste of the x509 certificate that was created when Conjur was initiated. The certificate is stored in a `.pem` file that was created by the `conjur init` command. The default path is `/conjur_install_directory/conjur-account.pem`.
 
-  *  The Service Broker requires a Conjur Host Factory to use when adding host identities. The examples below in  [Recommendations](#recommendations) include Host Factory definitions. If a Host Factory is not properly defined, a health check near the end of tile installation reports the condition, and the tile installation fails.
+  *  The Service Broker requires a Conjur Host Factory to use when adding Host identities. The examples below in [Recommendations](#recommendations) include Host Factory definitions. If a Host Factory is not properly defined, a health check near the end of tile installation reports the condition, and the tile installation fails.
 
 
 ## <a id="recommendations"></a>Recommendations
 
-### Declare a Dedicated PCF Namespace
+### Declare a Dedicated PCF Policy
 
- CyberArk strongly recommends that you create a Conjur namespace dedicated to PCF.  Create this namespace before installing the PCF tile.
+ CyberArk strongly recommends that you create a Conjur Policy dedicated to PCF.  Create this Policy before installing the PCF tile.
 
-  A Conjur *namespace* is a policy ID loaded under the root policy. For example:
+  The syntax for defining a Conjur Policy with ID `my-pcf` is as follows:
 
 ```
 - !policy
   id: my-pcf
 ```
 
-A dedicated namespace supports least privilege principles in the following ways:
+  This can be loaded into the root Policy or any other Conjur Policy you would like. Host identities for PCF-deployed applications
+  will be loaded into the `my-pcf` Conjur Policy when the applications are bound to a Conjur service instance.
 
-  * The secrets, host identities, and  access control policies for your PCF-deployed applications are isolated from other resources stored in Conjur.
-  *  Conjur access privileges required by the Service Broker, DevOps teams, and your applications can be limited in scope to the PCF namespace.
-  * You can give a limited set of Conjur users access to PCF, with even finer-grained permissions possible within the policy namespace itself.
-  *  For Conjur Enterprise (v4), you can define the Host Factory layer in the PCF policy, rather than in the root policy.
+A dedicated PCF Policy supports least privilege principles in the following ways:
 
-When creating the Conjur policy that declares users in the PCF space, consider the following:
+  * The secrets, Host identities, and access control policies for your PCF-deployed applications are isolated from other resources stored in Conjur.
+  * Conjur access privileges required by the Service Broker, DevOps teams, and your applications can be limited in scope to the PCF Policy.
+  * You can give a limited set of Conjur users access to PCF, with even finer-grained permissions possible within the PCF Policy itself.
+  * For Conjur Enterprise (v4), you can define the Host Factory layer in the PCF Policy, rather than in the root Policy.
 
- * The Service Broker requires `create` and `update` privileges on the policy namespace to add and remove host identities. Members of the owner group have those privileges.
+When creating the Conjur Policy for PCF, consider the following:
+
+ * The Service Broker requires `create` and `update` privileges on the Policy to add and remove Host identities. Members of the Group that owns the Policy have those privileges.
  * PCF DevOps personnel need access to Conjur to declare application secrets and grant privileges to the applications to access those secrets.
- * For Conjur Enterprise (v4), a host-factory layer is required. Both the layer name and the host-factory name must use the syntax `namespace-apps`, where apps is a constant. For example, pcf-apps is used in the  policy example shown below.
+ * For Conjur Enterprise (v4), a Host Factory is required. Both the ID of the Layer and the Host Factory must use the syntax `namespace-apps`, where `apps` is a constant. For example, `pcf-apps` is used in the policy example shown below.
 
 
-To create a dedicated PCF namespace:
+To create a dedicated PCF Policy:
 
-1. Create a policy using the following example as a guide.   Save the policy as a .yml file.
+Step 1: Create a policy using the following example as a guide.  Save the policy as a `.yml` file.
 
- Example Policy Declaring a Dedicated PCF Space:
+ Example policy file declaring a dedicated PCF Policy:
 
    ```
-
-  - !user
-    id: pcf-admin
+  - !host
+    id: pcf-service-broker
 
   - !group
     id: pcf-admin-group
 
   - !grant
     role: !group pcf-admin-group
-    member: !user pcf-admin
+    member: !host pcf-service-broker
 
   - !policy
     id: pcf                          /* Namespace name
@@ -149,8 +151,13 @@ To create a dedicated PCF namespace:
         layers: [ !layer pcf-apps ]
    ```
 
+   This policy file creates a Host identity `host/pcf-service-broker` that can be used as the `CONJUR_AUTHN_LOGIN` role in the Tile configuration.
+   The `pcf-service-broker` Host is a member of the `pcf-admin-group` Group, which owns the `pcf` Policy, so it has `create` and `update` privileges on that Policy as required.
+   The `pcf` Policy has a `pcf-apps` Layer and corresponding Host-Factory; if using Conjur version 4, application Hosts will be added to the `pcf-apps` Layer via the `pcf-apps` Host Factory when the application is bound to a Conjur service instance.
+   Additional policies for individual applications can be appended to this file or loaded in separate `.yml` files as needed.
 
-3. Load the policy into Conjur under the root policy, as follows:
+
+Step 2. Load the policy into Conjur as follows (in this example, we are loading it into the root Policy):
 
    For Conjur Enterprise (v4):
 
@@ -164,26 +171,28 @@ To create a dedicated PCF namespace:
    $ conjur policy load root your-pcf-policy-file.yml
    ```
 
-3. In the CyberArk Conjur Service Broker for PCF tile configuration:
-  *  For **PCF Conjur Policy Namespace**, use the policy id (`pcf` in the above example)
-  *  For **Conjur Login**, use a Conjur user who is a member of the group that owns the PCF policy namespace.
-  *  For **Conjur API Key**, use that user's API key. The admin who created the role can retrieve the value with this command:
+Step 3. In the CyberArk Conjur Service Broker for PCF tile configuration:
+  *  For **PCF Conjur Policy Namespace**, use the Policy ID (`pcf` in the above example)
+  *  For **Conjur Login**, use a Conjur Host who is a member of the Group that owns the PCF Policy (`host/pcf-service-broker` in the example above).
+  *  For **Conjur API Key**, use that Host's API key. The admin who created the role can retrieve the value with this command:
 
      ```
-    $ conjur user rotate_api_key -u the-login-name
+    $ conjur host rotate_api_key -h pcf-service-broker
      ```
 
-### Use the Default Root Namespace
+### Use the Default Root Policy
 
-If you decide to use the default root namespace for PCF, consider the following:
+If you decide to use the default root Policy for PCF, consider the following:
 
 * You are not following least privilege best practice.
 
-* The admin user that you provide on tile installation must have the ability to update root policy, and the Service Broker will add   host identities for your PCF applications to the root policy.
+* The admin Host that you provide on tile installation must have `create` and `update` privileges on the root Policy, which means that it will be privileged to edit _any Policy in your Conjur installation_.
 
-* The PCF DevOps teams will be altering policy files in the root space.
+* The Service Broker will add Host identities for your PCF applications to the root Policy.
 
-* For integration with Conjur v4, a Host Factory named  `apps` is required.  Add the following layer declaration to the root policy:
+* The PCF DevOps teams will be altering policy files in the root Policy.
+
+* For integration with Conjur v4, a Host Factory named `apps` is required.  Add the following layer declaration to the root Policy:
 
 
  ```

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -116,14 +116,13 @@ When creating the dedicated Conjur policy for PCF, consider the following:
 
  * The Service Broker requires `create` and `update` privileges on the policy to add and remove host identities. Members of the group that owns the policy have those privileges.
  * PCF DevOps personnel need access to Conjur to declare application secrets and grant privileges to the applications to access those secrets.
- * For Conjur Enterprise (v4), a Host Factory is required. Both the ID of the Layer and the Host Factory must use the syntax `namespace-apps`, where `apps` is a constant. For example, `pcf-apps` is used in the policy example shown below.
+ * For Conjur Enterprise (v4), a Host Factory is required. Both the ID of the Layer and the Host Factory must use the syntax `[policy-id]-apps`, where `apps` is a constant. For example, `pcf-apps` is used in the policy example shown below where the dedicated policy for PCF is called `pcf`.
 
 
 To create a dedicated Conjur policy for PCF:
 
 Step 1: Create a policy using the following example as a guide.  Save the policy as a `.yml` file.
 
- Example policy file that creates a dedicated Conjur policy `pcf` for PCF:
 
    ```
   - !host
@@ -137,14 +136,13 @@ Step 1: Create a policy using the following example as a guide.  Save the policy
     member: !host pcf-service-broker
 
   - !policy
-    id: pcf                          /* Namespace name
-                                     /* It does not have to be pcf
-    owner: !group pcf-admin-group    /* Owners have complete privileges
+    id: pcf                          /* Policy does not have to be called pcf
+    owner: !group pcf-admin-group    /* Owners have complete privileges on the policy
     body:                            /* The body and following layer are
       - !layer pcf-apps              /* required for Conjur Enterprise v4;
                                      /* optional otherwise.
                                      /* Layer name and host-factory name
-                                     /* must be namespace-apps
+                                     /* must be [policy-id]-apps
 
       - !host-factory
         id: pcf-apps

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -119,9 +119,9 @@ When creating the dedicated Conjur policy for PCF, consider the following:
  * For Conjur Enterprise (v4), a Host Factory is required. Both the ID of the Layer and the Host Factory must use the syntax `[policy-id]-apps`, where `apps` is a constant. For example, `pcf-apps` is used in the policy example shown below where the dedicated policy for PCF is called `pcf`.
 
 
-To create a dedicated Conjur policy for PCF:
+#### To create a dedicated Conjur policy for PCF:
 
-Step 1: Create a policy using the following example as a guide.  Save the policy as a `.yml` file.
+##### Step 1: Create a policy using the following example as a guide.  Save the policy as a `.yml` file.
 
 
    ```
@@ -136,7 +136,7 @@ Step 1: Create a policy using the following example as a guide.  Save the policy
     member: !host pcf-service-broker
 
   - !policy
-    id: pcf                          /* Policy does not have to be called pcf
+    id: pcf                          /* Policy ID does not have to be pcf
     owner: !group pcf-admin-group    /* Owners have complete privileges on the policy
     body:                            /* The body and following layer are
       - !layer pcf-apps              /* required for Conjur Enterprise v4;
@@ -150,12 +150,15 @@ Step 1: Create a policy using the following example as a guide.  Save the policy
    ```
 
    This policy file creates a `host/pcf-service-broker` Host that can be used as the `CONJUR_AUTHN_LOGIN` role in the Tile configuration.
+
    The `pcf-service-broker` Host is a member of the `pcf-admin-group` Group, which owns the `pcf` Policy, so it has `create` and `update` privileges on that Policy as required.
+
    The `pcf` Policy has a `pcf-apps` Layer and corresponding Host-Factory; if using Conjur version 4, application Hosts will be added to the `pcf-apps` Layer via the `pcf-apps` Host Factory when the application is bound to a Conjur service instance.
+
    Additional policies for individual applications can be appended to this file or loaded in separate `.yml` files as needed.
 
 
-Step 2. Load the policy into Conjur as follows (in this example, we are loading it into the root policy):
+##### Step 2. Load the policy into Conjur as follows (in this example, we are loading it into the root policy):
 
    For Conjur Enterprise (v4):
 
@@ -169,9 +172,9 @@ Step 2. Load the policy into Conjur as follows (in this example, we are loading 
    $ conjur policy load root your-pcf-policy-file.yml
    ```
 
-Step 3. In the CyberArk Conjur Service Broker for PCF tile configuration:
-  *  For **PCF Conjur Policy Namespace**, use the full path to the dedicated Conjur policy for PCF (`pcf` in the above example)
-  *  For **Conjur Login**, use a Conjur Host who is a member of the Group that owns the PCF Policy (`host/pcf-service-broker` in the example above).
+##### Step 3. In the CyberArk Conjur Service Broker for PCF tile configuration:
+  *  For **PCF Conjur Policy Namespace**, use the fully-qualified ID of the dedicated Conjur policy for PCF (`pcf` in the above example)
+  *  For **Conjur Login**, use a Conjur Host who is a member of the Conjur Group that owns the PCF Policy (`host/pcf-service-broker` in the example above).
   *  For **Conjur API Key**, use that Host's API key. The admin who created the role can retrieve the value with this command:
 
      ```

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -183,7 +183,7 @@ When creating the dedicated Conjur policy for PCF, consider the following:
 
 ### Use the Default Root Policy
 
-If you decide to use leave the **PCF Conjur Policy Namespace** blank in the tile configuration (that is, you choose to use the default root policy), consider the following:
+If you decide to leave the **PCF Conjur Policy Namespace** blank in the tile configuration (that is, you choose to use the default root policy), consider the following:
 
 * You are not following least privilege best practice.
 

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -2,7 +2,7 @@
 title: Installing and Configuring CyberArk Conjur Service Broker for PCF
 owner: Partners
 ---
- 
+
 
 This topic describes how to install and configure CyberArk Conjur Service Broker for Pivotal Cloud Foundry (PCF).
 
@@ -10,85 +10,85 @@ This topic describes how to install and configure CyberArk Conjur Service Broker
 
 1. Download the CyberArk Conjur Service Broker for PCF product file from <a href = "https://network.pivotal.io">Pivotal Network</a>.
 
-1. Navigate to the Ops Manager Installation Dashboard and click **Import a Product** to upload the product file. 
+1. Navigate to the Ops Manager Installation Dashboard and click **Import a Product** to upload the product file.
 
-1. Under the **Import a Product** button, click **+** next to the version number of CyberArk Conjur Service Broker for PCF. 
+1. Under the **Import a Product** button, click **+** next to the version number of CyberArk Conjur Service Broker for PCF.
 This adds the tile to your staging area.
 
 1. Click the newly added **CyberArk Conjur Service Broker for PCF** tile.
 
-1. Click the **Settings** tab.  
+1. Click the **Settings** tab.
 
-1. Configure the side tabs. The tabs with orange circles require configuration. The others are optional.           
+1. Configure the side tabs. The tabs with orange circles require configuration. The others are optional.
   * [Assign AZs and Networks](#assign-az)
-  * [Service Broker Configuration](#config-service-broker)  
+  * [Service Broker Configuration](#config-service-broker)
   * [Service Access](#config-service-access)
   * [Stemcell](#config-stemcell)
 
 1. Click **Save**.
 
 1. Return to the Ops Manager Installation Dashboard and click **Apply changes** to apply the configuration changes and complete the installation of the CyberArk Conjur Service Broker for PCF tile.
- 
-1. Use `cf marketplace` to verify availability of the community service named `cyberark-conjur`.  
+
+1. Use `cf marketplace` to verify availability of the community service named `cyberark-conjur`.
 
 ###<a id='assign-az'></a>Assign AZs and Networks
 
-Choose appropriate values to configure where to deploy CyberArk Conjur Service Broker for PCF.    
+Choose appropriate values to configure where to deploy CyberArk Conjur Service Broker for PCF.
 
-###<a id='config-service-broker'></a>Service Broker Configuration  
+###<a id='config-service-broker'></a>Service Broker Configuration
 
-This tab configures communication between the Service Broker and a Conjur appliance. 
+This tab configures communication between the Service Broker and a Conjur appliance.
 
 ![Conjur Service Broker Configuration tab](service_broker_config_screen.png)
 
   * **Conjur Account**: The organization account assigned during Conjur appliance installation. If you are using a hosted Conjur instance for a proof of concept, the account is typically your email address.
-  
+
   * **Conjur Appliance URL**: The URL of the Conjur appliance that you are connecting to.
-  
-  * **Conjur Login**: The username of a Conjur user. 
-  
-  The user  must have `create` and `update`  privileges on the Conjur policy on the dedicated PCF policy ID you enter in the **PCF Conjur Policy Namespace** field. If you are not using a dedicated PCF policy namespace, this login user must have `create` and `update` privileges on the Conjur root policy. 
-  
-  This login is only used by the Service Broker to add and remove hosts from the Conjur policy files as your applications are deployed to or removed from PCF. 
 
-  * **Conjur API Key**: The API key of the Conjur user whose username you provided in the **Conjur Login** field. 
+  * **Conjur Login**: The identity of a Conjur Host.
 
-  If the user's API key changes, you need to update this field and click **Apply Changes** to continue using the Service Broker to bind applications. After binding, an application has its own credentials for connecting to the Conjur appliance.        
+  The Host must have `create` and `update` privileges on the Conjur Policy that you enter in the **PCF Conjur Policy Namespace** field. If you are not using a dedicated PCF Policy, this login Host must have `create` and `update` privileges on the Conjur root policy.
 
-<p class='note'><strong>Note:</strong> The Conjur user credentials configured here are available only to PCF admins. They are not generally accessible to users in PCF.</p>
+  This login is only used by the Service Broker to add and remove Hosts from Conjur policy as your applications are deployed to or removed from PCF.
 
-  * **Conjur Policy**: The policy namespace you created for PCF. Leave blank to default to the root policy (not recommended). 
-  
+  This entry should be of the form `host/host-id`, where `host-id` is the ID value you gave to the Host in Conjur policy. The `host/` prefix indicates to the Conjur authenticator that these credentials belong to a Host, and not a User.
+
+  * **Conjur API Key**: The API key of the Conjur Host whose identity you provided in the **Conjur Login** field.
+
+  If the Host's API key changes, you need to update this field and click **Apply Changes** to continue using the Service Broker to bind applications. After binding, an application has its own credentials for connecting to the Conjur appliance.
+
+<p class='note'><strong>Note:</strong> The Conjur Host credentials configured here are available only to PCF admins. They are not generally accessible to users in PCF.</p>
+
+  * **PCF Conjur Policy Namespace**: The Conjur Policy you created for PCF. Leave blank to default to the root policy (not recommended).
+
   * **Conjur Version**: Defaults to 5. Select 4 for Enterprise Conjur. Select 5 for Open Source Conjur (including an evaluation Hosted Conjur).
-  
-  * **Conjur Certificate**: Required for Conjur Enterprise only. Copy and paste the contents of the .pem file that was created by the `conjur init` command when the Conjur appliance was configured. Be sure to include the Begin and End lines in the certificate.  
-  
-  The .pem file is located in the root folder where Conjur was created. The file name is `conjur-account.pem`, where *account* is the account name provided for  the  Conjur instance.
 
-###<a id='config-buildpack'></a>Buildpack Setttings  
+  * **Conjur Certificate**: Required for Conjur Enterprise only. Copy and paste the contents of the .pem file that was created by the `conjur init` command when the Conjur appliance was configured. Be sure to include the Begin and End lines in the certificate.
 
-Do not change the installed sequence. `meta_buildpack` must install first, and `conjur_buildpack` must install second. 
+  The .pem file is located in the root folder where Conjur was created. The file name is `conjur-account.pem`, where *account* is the account name provided for the Conjur instance.
+
+###<a id='config-buildpack'></a>Buildpack Setttings
+
+Do not change the installed sequence. `meta_buildpack` must install first, and `conjur_buildpack` must install second.
 
 ###<a id='config-service-access'></a>Service Access
 
-If **Enable global access to plans of service Conjur** is checked, the Conjur service is available to all PCF users, across all orgs and spaces.   
-   
-To configure more precise access control, uncheck this option and use `cf enable-service-access` to specify which orgs and spaces can access the Conjur service.    
+If **Enable global access to plans of service Conjur** is checked, the Conjur service is available to all PCF users, across all orgs and spaces.
+
+To configure more precise access control, uncheck this option and use `cf enable-service-access` to specify which orgs and spaces can access the Conjur service.
 
 ###<a id='config-errands'></a>Errands
 
-The CyberArk Conjur Service Broker for PCF tile does not add any errands.  
+The CyberArk Conjur Service Broker for PCF tile does not add any errands.
 
-###<a id='config-resources'></a>Resource Config 
+###<a id='config-resources'></a>Resource Config
 
-The default settings are appropriate. 
+The default settings are appropriate.
 
-###<a id='config-stemcell'></a>Stemcell 
- 
-The latest major stemcell release is required by CyberArk Conjur Service Broker for PCF. 
+###<a id='config-stemcell'></a>Stemcell
+
+The latest major stemcell release is required by CyberArk Conjur Service Broker for PCF.
 
 If the Stemcell side tab has a green checkmark, you have the latest release and no action is required.
 
-If the Stemcell side tab has an orange circle, install the requested stemcell. 
- 
-
+If the Stemcell side tab has an orange circle, install the requested stemcell.

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -41,17 +41,21 @@ This tab configures communication between the Service Broker and a Conjur applia
 
 ![Conjur Service Broker Configuration tab](service_broker_config_screen.png)
 
+*Note*: in the instructions below, you are asked to provide the ID for a Conjur Host or Policy.
+It is worth noting that by convention, Conjur IDs are path-based.
+For example: a `pcf` Platform loaded into a `prod/platforms` policy namespace wuold have ID `prod/platforms/pcf`.
+
   * **Conjur Account**: The organization account assigned during Conjur appliance installation. If you are using a hosted Conjur instance for a proof of concept, the account is typically your email address.
 
   * **Conjur Appliance URL**: The URL of the Conjur appliance that you are connecting to.
 
   * **Conjur Login**: The identity of a Conjur Host.
 
-  The Host must have `create` and `update` privileges on the Conjur Policy that you enter in the **PCF Conjur Policy Namespace** field. If you are not using a dedicated PCF Policy, this login Host must have `create` and `update` privileges on the Conjur root policy.
+  The Host must have `create` and `update` privileges on the dedicated Conjur policy for PCF that you enter in the **PCF Conjur Policy Namespace** field. If you are not using a dedicated Conjur policy for PCF, this login Host must have `create` and `update` privileges on the Conjur root policy.
 
   This login is only used by the Service Broker to add and remove Hosts from Conjur policy as your applications are deployed to or removed from PCF.
 
-  This entry should be of the form `host/host-id`, where `host-id` is the ID value you gave to the Host in Conjur policy. The `host/` prefix indicates to the Conjur authenticator that these credentials belong to a Host, and not a User.
+  This entry should be of the form `host/host-id`, where `host-id` is the Conjur Host ID. The `host/` prefix indicates to the Conjur authenticator that these credentials belong to a Host, and not a User.
 
   * **Conjur API Key**: The API key of the Conjur Host whose identity you provided in the **Conjur Login** field.
 
@@ -59,7 +63,7 @@ This tab configures communication between the Service Broker and a Conjur applia
 
 <p class='note'><strong>Note:</strong> The Conjur Host credentials configured here are available only to PCF admins. They are not generally accessible to users in PCF.</p>
 
-  * **PCF Conjur Policy Namespace**: The Conjur Policy you created for PCF. Leave blank to default to the root policy (not recommended).
+  * **PCF Conjur Policy Namespace**: The Conjur Policy ID of the dedicated Conjur policy for PCF that you created. Leave blank to default to the root policy (not recommended).
 
   * **Conjur Version**: Defaults to 5. Select 4 for Enterprise Conjur. Select 5 for Open Source Conjur (including an evaluation Hosted Conjur).
 

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -47,17 +47,17 @@ This tab configures communication between the Service Broker and a Conjur applia
 
   * **Conjur Login**: The fully-qualified ID of a Conjur Host.
 
-  The Host must have `create` and `update` privileges on the dedicated Conjur policy for PCF that you enter in the **PCF Conjur Policy Namespace** field. If you are not using a dedicated Conjur policy for PCF, this login Host must have `create` and `update` privileges on the Conjur root policy.
+    The Host must have `create` and `update` privileges on the dedicated Conjur policy for PCF that you enter in the **PCF Conjur Policy Namespace** field. If you are not using a dedicated Conjur policy for PCF, this login Host must have `create` and `update` privileges on the Conjur root policy.
 
-  This login is only used by the Service Broker to add and remove Hosts from Conjur policy as your applications are deployed to or removed from PCF.
+    This login is only used by the Service Broker to add and remove Hosts from Conjur policy as your applications are deployed to or removed from PCF.
 
-  This entry should be of the form `host/host-id`, where `host-id` is the fully-qualified Conjur Host ID. The `host/` prefix indicates to the Conjur authenticator that these credentials belong to a Host, and not a User.
+    This entry should be of the form `host/host-id`, where `host-id` is the fully-qualified Conjur Host ID. The `host/` prefix indicates to the Conjur authenticator that these credentials belong to a Host, and not a User.
 
   * **Conjur API Key**: The API key of the Conjur Host whose identity you provided in the **Conjur Login** field.
 
-  If the Host's API key changes, you need to update this field and click **Apply Changes** to continue using the Service Broker to bind applications. After binding, an application has its own credentials for connecting to the Conjur appliance.
+    If the Host's API key changes, you need to update this field and click **Apply Changes** to continue using the Service Broker to bind applications. After binding, an application has its own credentials for connecting to the Conjur appliance.
 
-<p class='note'><strong>Note:</strong> The Conjur Host credentials configured here are available only to PCF admins. They are not generally accessible to users in PCF.</p>
+    <p class='note'><strong>Note:</strong> The Conjur Host credentials configured here are available only to PCF admins. They are not generally accessible to users in PCF.</p>
 
   * **PCF Conjur Policy Namespace**: The fully-qualified Conjur Policy ID of the dedicated Conjur policy for PCF that you created. Leave blank to default to the root policy (not recommended).
 
@@ -65,7 +65,7 @@ This tab configures communication between the Service Broker and a Conjur applia
 
   * **Conjur Certificate**: Required for Conjur Enterprise only. Copy and paste the contents of the .pem file that was created by the `conjur init` command when the Conjur appliance was configured. Be sure to include the Begin and End lines in the certificate.
 
-  The .pem file is located in the root folder where Conjur was created. The file name is `conjur-account.pem`, where *account* is the account name provided for the Conjur instance.
+    The .pem file is located in the root folder where Conjur was created. The file name is `conjur-account.pem`, where *account* is the account name provided for the Conjur instance.
 
 ###<a id='config-buildpack'></a>Buildpack Setttings
 

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -45,7 +45,7 @@ This tab configures communication between the Service Broker and a Conjur applia
 
   * **Conjur Appliance URL**: The URL of the Conjur appliance that you are connecting to.
 
-  * **Conjur Login**: The full-qualified ID of a Conjur Host.
+  * **Conjur Login**: The fully-qualified ID of a Conjur Host.
 
   The Host must have `create` and `update` privileges on the dedicated Conjur policy for PCF that you enter in the **PCF Conjur Policy Namespace** field. If you are not using a dedicated Conjur policy for PCF, this login Host must have `create` and `update` privileges on the Conjur root policy.
 

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -41,15 +41,14 @@ This tab configures communication between the Service Broker and a Conjur applia
 
 ![Conjur Service Broker Configuration tab](service_broker_config_screen.png)
 
-*Note*: in the instructions below, you are asked to provide the ID for a Conjur Host or Policy.
-It is worth noting that by convention, Conjur IDs are path-based.
-For example: a `pcf` Platform loaded into a `prod/platforms` policy namespace wuold have ID `prod/platforms/pcf`.
+*Note*: in the instructions below, when a global identity is requested, please supply the ID of the Host or Policy prefixed by the namespace that the Host or Policy belongs to.
+For example: a `pcf` policy loaded into a `prod/platforms` policy namespace would have global ID `prod/platforms/pcf`.
 
   * **Conjur Account**: The organization account assigned during Conjur appliance installation. If you are using a hosted Conjur instance for a proof of concept, the account is typically your email address.
 
   * **Conjur Appliance URL**: The URL of the Conjur appliance that you are connecting to.
 
-  * **Conjur Login**: The identity of a Conjur Host.
+  * **Conjur Login**: The global identity of a Conjur Host.
 
   The Host must have `create` and `update` privileges on the dedicated Conjur policy for PCF that you enter in the **PCF Conjur Policy Namespace** field. If you are not using a dedicated Conjur policy for PCF, this login Host must have `create` and `update` privileges on the Conjur root policy.
 
@@ -63,7 +62,7 @@ For example: a `pcf` Platform loaded into a `prod/platforms` policy namespace wu
 
 <p class='note'><strong>Note:</strong> The Conjur Host credentials configured here are available only to PCF admins. They are not generally accessible to users in PCF.</p>
 
-  * **PCF Conjur Policy Namespace**: The Conjur Policy ID of the dedicated Conjur policy for PCF that you created. Leave blank to default to the root policy (not recommended).
+  * **PCF Conjur Policy Namespace**: The global Conjur Policy ID of the dedicated Conjur policy for PCF that you created. Leave blank to default to the root policy (not recommended).
 
   * **Conjur Version**: Defaults to 5. Select 4 for Enterprise Conjur. Select 5 for Open Source Conjur (including an evaluation Hosted Conjur).
 

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -41,20 +41,17 @@ This tab configures communication between the Service Broker and a Conjur applia
 
 ![Conjur Service Broker Configuration tab](service_broker_config_screen.png)
 
-*Note*: in the instructions below, when a global identity is requested, please supply the ID of the Host or Policy prefixed by the namespace that the Host or Policy belongs to.
-For example: a `pcf` policy loaded into a `prod/platforms` policy namespace would have global ID `prod/platforms/pcf`.
-
   * **Conjur Account**: The organization account assigned during Conjur appliance installation. If you are using a hosted Conjur instance for a proof of concept, the account is typically your email address.
 
   * **Conjur Appliance URL**: The URL of the Conjur appliance that you are connecting to.
 
-  * **Conjur Login**: The global identity of a Conjur Host.
+  * **Conjur Login**: The full-qualified ID of a Conjur Host.
 
   The Host must have `create` and `update` privileges on the dedicated Conjur policy for PCF that you enter in the **PCF Conjur Policy Namespace** field. If you are not using a dedicated Conjur policy for PCF, this login Host must have `create` and `update` privileges on the Conjur root policy.
 
   This login is only used by the Service Broker to add and remove Hosts from Conjur policy as your applications are deployed to or removed from PCF.
 
-  This entry should be of the form `host/host-id`, where `host-id` is the Conjur Host ID. The `host/` prefix indicates to the Conjur authenticator that these credentials belong to a Host, and not a User.
+  This entry should be of the form `host/host-id`, where `host-id` is the fully-qualified Conjur Host ID. The `host/` prefix indicates to the Conjur authenticator that these credentials belong to a Host, and not a User.
 
   * **Conjur API Key**: The API key of the Conjur Host whose identity you provided in the **Conjur Login** field.
 
@@ -62,7 +59,7 @@ For example: a `pcf` policy loaded into a `prod/platforms` policy namespace woul
 
 <p class='note'><strong>Note:</strong> The Conjur Host credentials configured here are available only to PCF admins. They are not generally accessible to users in PCF.</p>
 
-  * **PCF Conjur Policy Namespace**: The global Conjur Policy ID of the dedicated Conjur policy for PCF that you created. Leave blank to default to the root policy (not recommended).
+  * **PCF Conjur Policy Namespace**: The fully-qualified Conjur Policy ID of the dedicated Conjur policy for PCF that you created. Leave blank to default to the root policy (not recommended).
 
   * **Conjur Version**: Defaults to 5. Select 4 for Enterprise Conjur. Select 5 for Open Source Conjur (including an evaluation Hosted Conjur).
 

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -159,13 +159,15 @@ Binding occurs automatically if the application manifest contains the correct se
 
 The binding process generates a binding ID that becomes the Conjur Host ID, used as a unique application identity for this application running in this space.
 
-The ID is stored in the `authn_login` string found under the VCAP_SERVICES environment variable. The `authn_login` string has the format `host/namespace/binding_id`. For example:
+The ID is stored in the `authn_login` string found under the VCAP_SERVICES environment variable. The `authn_login` string has the format `host/global-policy-id/binding_id`. For example:
 
     `host/pcf/0299a19d-7de4-4e98-89f6-372ac7c0521f`
 
+would be the value of `authn_login` if the tile was configured to add hosts to the `pcf` Conjur Policy.
+
 The following command extracts just the binding ID value that you need.
 
-<pre class='term'>$ cf env $APP_NAME | grep authn_login | awk '{print $NF}' | sed 's/host\///g; s/"//g; s/,$//g'</pre>
+<pre class='term'>$ cf env $APP_NAME | grep authn_login | awk '{print $NF}' | sed 's/host.*\///g; s/"//g; s/,$//g'</pre>
 
 
 ####<a id="update-policy"></a>Step 6: Update Conjur Policy Grants for this Application
@@ -184,7 +186,7 @@ The binding ID obtained in the previous step becomes the Host ID to use in Conju
    ```
 3. Load the policy change:
 
- The following command loads the new policy file into a namespace called `pcf`:
+ The following command loads the grant in `entitlements.yml` into the `pcf` Conjur policy:
 <pre class='term'>$ conjur policy load pcf entitlements.yml</pre>
 
  In Enterprise Conjur (v4), you could also choose to use an `!include` statement in the existing PCF Policy.

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -7,16 +7,16 @@ This topic describes how to use CyberArk Conjur Service Broker for Pivotal Cloud
 
 ##<a id='using'></a> Using CyberArk Conjur Service Broker for PCF
 
-The CyberArk Conjur Service Broker for PCF provides the interface between PCF applications and a Conjur appliance. 
+The CyberArk Conjur Service Broker for PCF provides the interface between PCF applications and a Conjur appliance.
 
  - [Deploy a PCF Application that Accesses Secrets from Conjur](#deploy-application)
  - [Use a Custom Buildpack](#custom-bp)
- 
-###<a id='deploy-application'></a>Deploy a PCF Application that Accesses Secrets from Conjur   
+
+###<a id='deploy-application'></a>Deploy a PCF Application that Accesses Secrets from Conjur
 
 This procedure enables a PCF application to obtain secrets and manage authorization privileges from an existing Conjur appliance.
 
-You can push the same application to multiple spaces. After preparing the application as described in Step 1 below, target your desired orgs and spaces and perform the remaining steps for each space.    
+You can push the same application to multiple spaces. After preparing the application as described in Step 1 below, target your desired orgs and spaces and perform the remaining steps for each space.
 
  - [Step 1: Prepare the Application](#secrets)
  - [Step 2: Create a Service Instance](#create-service)
@@ -28,73 +28,74 @@ You can push the same application to multiple spaces. After preparing the applic
 
 ####<a id="secrets"></a>Step 1: Prepare the Application
 
-The CyberArk Conjur Service Broker for PCF uses the Summon application included in the Conjur Buildpack by default to fetch secrets from the Conjur appliance and inject the values into your application's environment.  
+The CyberArk Conjur Service Broker for PCF uses the Summon application included in the Conjur Buildpack by default to fetch secrets from the Conjur appliance and inject the values into your application's environment.
 
-The secrets, fetched at application startup, are available only to the application process (not to users), and are gone when the process exits.  Summon requires a `secrets.yml` file in the application's root folder. 
+The secrets, fetched at application startup, are available only to the application process (not to users), and are gone when the process exits.  Summon requires a `secrets.yml` file in the application's root folder.
 
-If your application uses another method to access secrets, such as Conjur API calls, you do not need a `secrets.yml` file.  
+If your application uses another method to access secrets, such as Conjur API calls, you do not need a `secrets.yml` file.
 
   1. Create a file named `secrets.yml`.
- 
-  2. Add entries to the file to define the secrets that the application will fetch. Secrets to fetch from Conjur are specified with a !<tag> and a pathname indicating the Conjur policy path.  
- 
-  2. Store the `secrets.yml` file in the root folder of your application. 
-  
-  4. Create Conjur policy that declares the secrets as Conjur variables and, if desired, grants access to them for users.   [A later step](#update-policy) grants access to the PCF application.  
-  
-  5. Load the policy into Conjur under the PCF namespace. For example, the following examples load a policy file named `my-app.yml` into a Conjur namespace named `pcf`. 
-  
-  For Enterprise Conjur (v4): 
-  
-  Add `!include my-app.yml` to an existing PCF policy file (`pcf.yml` in the example below) and reload the policy as follows:  
-  
+
+  2. Add entries to the file to define the secrets that the application will fetch. Secrets to fetch from Conjur are specified with a `!<tag>` and a pathname indicating the Conjur policy path.
+
+  2. Store the `secrets.yml` file in the root folder of your application.
+
+  4. If the secrets that your application needs are not already available in Conjur policy, you can create a policy file `my-app.yml` that will add the secrets to policy. The `my-app` Policy can also create a Group that is entitled to fetch the secret values; the application Host can be added to that Group in [a later step](#update-policy) to grant it access to the secret values.
+
+  5. If you created a `my-app.yml` policy file, load it into Conjur under the PCF Policy. For example, if your PCF Policy is called `pcf`:
+
+  For Enterprise Conjur (v4):
+
+  Add `!include my-app.yml` under the PCF Policy (defined in `pcf.yml` in the example below) and reload the policy as follows:
+
   ```
   $ conjur policy load --as-group security_admin pcf.yml
 
   ```
-  If the policy file contains only PCF-related policy, you could also load with an admin group that is defined within the PCF policy, as follows: 
-  
+  If `pcf.yml` contains only the PCF Policy, and if we have set that Policy so that it is owned by the `pcf-admin-group`, you could also reload by calling:
+
   ```
   $ conjur policy load --as-group pcf-admin-group pcf.yml
   ```
-  
-  
-  For Open Source Conjur (v5): 
-  
+
+
+  For Open Source Conjur (v5):
+
   ```
   $ conjur policy load pcf my-app.yml
-  ``` 
+  ```
 
 ##### Example: secrets.yml
 
-The following example of a `secrets.yml` file shows several types of allowed entries.  
- 
+The following example of a `secrets.yml` file shows several types of allowed entries.
+
  ```
-DB_USERNAME: !var pcf/my-app/db/username 
+DB_USERNAME: !var pcf/my-app/db/username
 DB_PASSWORD: !var pcf/my-app/db/password
 REGION: us-east-1
 SSL_CERT: !var:file pcf/ssl/certs/private
  ```
 
 
-Lines 1 and 2 specify variables with pathnames containing a secret. In this case, assume that a policy with an id of `my-app` was loaded into the pcf policy namespace. The pathnames are Conjur policy paths, using the PCF namespace as the first component, followed by other ids in the policy hierarchy. 
-Line 3 specifies a literal string for the secret. 
-Line 4 specifies a variable that is a file containing the secret. The contents of the file would also be retrieved from Conjur.
+Lines 1 and 2 specify fully qualified secret IDs. In this case, assume that a `my-app` Policy was loaded into the `pcf` Policy. Each secret ID is given by the full path to the secret in Conjur, using the `pcf` Policy as the first component, followed by other IDs in the policy hierarchy.
+Line 3 specifies a literal string value for the secret.
+Line 4 specifies a fully qualified secret ID, and indicates that the value of the secret should be written to a temp file and `SSL_CERT` should be set to the temp file path.
 
-In the context of a PCF environment, the above example could produce the following results, with the first two values retrieved from Conjur: 
- 
+
+In the context of a PCF environment, the above example could produce the following results, with the first two values and the contents of the file retrieved from Conjur:
+
 ```
 DB_USERNAME: AKIAI44QH8DHBEXAMPLE
 DB_PASSWORD: je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY
 REGION: us-east-1
 SSL_CERT: pcf/tmp/ssl-cert.pem
 ```
- 
-For more information about syntax and options for a `secrets.yml` file, see the secrets.yml section in the [Summon documentation](https://cyberark.github.io/summon/). 
+
+For more information about syntax and options for a `secrets.yml` file, see the secrets.yml section in the [Summon documentation](https://cyberark.github.io/summon/).
 
 #####Example: my-app.yml
 
-The following example shows a Conjur application policy declaring two secrets as variables for Conjur to manage and a group with access to those secrets. 
+The following example shows a Conjur application policy declaring two secrets as variables for Conjur to manage and a group with access to those secrets.
 
 ```
 - !policy
@@ -113,88 +114,88 @@ The following example shows a Conjur application policy declaring two secrets as
       role: !group secrets-users
 ```
 
-####<a id="create-service"></a>Step 2: Create a Service Instance  
+####<a id="create-service"></a>Step 2: Create a Service Instance
 
-In the PCF space where you intend to deploy the application, create a service instance.   
+In the PCF space where you intend to deploy the application, create a service instance.
 
 <pre class='term'>$ cf create-service cyberark-conjur community my-service-instance-name</pre>
 
 In the command above:
 
-* The service-name is `cyberark-conjur`. 
+* The service-name is `cyberark-conjur`.
 * There is a single free service plan called `community`.
-* For convenience, you may use the same instance-name in multiple PCF spaces, so that the same application manifest works in all spaces.      
+* For convenience, you may use the same instance-name in multiple PCF spaces, so that the same application manifest works in all spaces.
 
- 
-####<a id="edit-manifest"></a>Step 3: Edit Application Manifest  
 
-Add the instance-name from the previous step to the list of services in the application manifest (if you are using a manifest).  For example: 
- 
+####<a id="edit-manifest"></a>Step 3: Edit Application Manifest
+
+Add the instance-name from the previous step to the list of services in the application manifest (if you are using a manifest).  For example:
+
    ```
  applications:
   - name: my-app
     services:
-    - my-service-instance-name 
+    - my-service-instance-name
    ```
- 
+
 
 ####<a id="push-app"></a>Step 4: Push Application to PCF Space
 
-If your application lists buildpacks in its manifest or you need to list buildpacks in the `cf push` command, see [Use a Custom BuildPack](#custom-bp) before proceeding with this step.    
+If your application lists buildpacks in its manifest or you need to list buildpacks in the `cf push` command, see [Use a Custom BuildPack](#custom-bp) before proceeding with this step.
 
-Target your desired orgs and spaces and push the application and its associated files. 
+Target your desired orgs and spaces and push the application and its associated files.
 
 ```
-cf push ...   
+cf push ...
 ```
 Use the `--no-start` option to avoid starting the application before it is configured to work with Conjur.
 
- 
-####<a id="bind"></a>Step 5: Obtain the Binding ID  
 
-Binding occurs automatically if the application manifest contains the correct service instance name. If you are not using a manifest, run the `cf bind-service` command to bind the application manually. For example: 
+####<a id="bind"></a>Step 5: Obtain the Binding ID
+
+Binding occurs automatically if the application manifest contains the correct service instance name. If you are not using a manifest, run the `cf bind-service` command to bind the application manually. For example:
 
 (optional) <pre class='term'>$ cf bind-service my-app my-service-instance-name</pre>
 
-The binding process generates a binding ID that becomes the Conjur host ID, used as a unique application identity for this application running in this space.
+The binding process generates a binding ID that becomes the Conjur Host ID, used as a unique application identity for this application running in this space.
 
-The ID is stored in the `authn_login` string found under the VCAP_SERVICES environment variable. The `authn_login` string has the format `host/namespace/binding_id`. For example:   
-  
+The ID is stored in the `authn_login` string found under the VCAP_SERVICES environment variable. The `authn_login` string has the format `host/namespace/binding_id`. For example:
+
     `host/pcf/0299a19d-7de4-4e98-89f6-372ac7c0521f`
 
-The following command extracts just the binding ID value that you need. 
+The following command extracts just the binding ID value that you need.
 
 <pre class='term'>$ cf env $APP_NAME | grep authn_login | awk '{print $NF}' | sed 's/host\///g; s/"//g; s/,$//g'</pre>
 
 
-####<a id="update-policy"></a>Step 6: Update Conjur Policy Grants for this Application      
+####<a id="update-policy"></a>Step 6: Update Conjur Policy Grants for this Application
 
-The binding ID obtained in the previous step becomes the host ID to use in Conjur policies.  
+The binding ID obtained in the previous step becomes the Host ID to use in Conjur policies.
 
- 1. Log into the Conjur appliance.   
- 
- 2. Update policy to grant read and execute privileges to the new host ID on a set of secrets. 
-   
-   For example, the following policy adds the new host to the existing secrets-users group.  You can save these lines in a separate file, such as `entitlements.yml`.    
-   ``` 
+ 1. Log into the Conjur appliance.
+
+ 2. Update policy to grant read and execute privileges to the new Host ID on a set of secrets.
+
+   For example, the following policy adds the new host to the existing secrets-users group.  You can save these lines in a separate file, such as `entitlements.yml`.
+   ```
    - !grant
      role: !group my-app/secrets-users
      member: !host 0299a19d-7de4-4e98-89f6-372ac7c0521f
-   ```   
+   ```
 3. Load the policy change:
-  
- The following command loads the new policy file into a namespace called `pcf`:    
+
+ The following command loads the new policy file into a namespace called `pcf`:
 <pre class='term'>$ conjur policy load pcf entitlements.yml</pre>
 
- In Enterprise Conjur (v4), you could also choose to use an `!include` statement in the existing PCF policy.
+ In Enterprise Conjur (v4), you could also choose to use an `!include` statement in the existing PCF Policy.
 
-####<a id="restage"></a>Step 7: Restage the Application 
-  
-Start or restage the application. 
+####<a id="restage"></a>Step 7: Restage the Application
+
+Start or restage the application.
 
 <pre class='term'>$ cf restage my-app</pre>
 
-On application startup, the service loads the secrets that are defined in the application's `secrets.yml` into the PCF environment. 
+On application startup, the service loads the secrets that are defined in the application's `secrets.yml` into the PCF environment.
 
 
 ###<a id='custom-bp'></a>Use a Custom Buildpack

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -42,17 +42,17 @@ If your application uses another method to access secrets, such as Conjur API ca
 
   4. If the secrets that your application needs are not already available in Conjur policy, you can create a policy file `my-app.yml` that will add the secrets to policy. The `my-app` Policy can also create a Group that is entitled to fetch the secret values; the application Host can be added to that Group in [a later step](#update-policy) to grant it access to the secret values.
 
-  5. If you created a `my-app.yml` policy file, load it into Conjur under the PCF Policy. For example, if your PCF Policy is called `pcf`:
+  5. If you created a `my-app.yml` policy file, load it into Conjur under the dedicated Conjur policy for PCF. For example, if your dedicated Conjur policy for PCF is called `pcf`:
 
   For Enterprise Conjur (v4):
 
-  Add `!include my-app.yml` under the PCF Policy (defined in `pcf.yml` in the example below) and reload the policy as follows:
+  Add `!include my-app.yml` to the body of the `pcf` Policy (defined in `pcf.yml` in the example below) and reload the policy as follows:
 
   ```
   $ conjur policy load --as-group security_admin pcf.yml
 
   ```
-  If `pcf.yml` contains only the PCF Policy, and if we have set that Policy so that it is owned by the `pcf-admin-group`, you could also reload by calling:
+  If `pcf.yml` contains only the `pcf` Policy, and if we have set that Policy so that it is owned by the `pcf-admin-group` Group, you could also reload by calling:
 
   ```
   $ conjur policy load --as-group pcf-admin-group pcf.yml

--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -38,7 +38,7 @@ If your application uses another method to access secrets, such as Conjur API ca
 
   2. Add entries to the file to define the secrets that the application will fetch. Secrets to fetch from Conjur are specified with a `!<tag>` and a pathname indicating the Conjur policy path.
 
-  2. Store the `secrets.yml` file in the root folder of your application.
+  3. Store the `secrets.yml` file in the root folder of your application.
 
   4. If the secrets that your application needs are not already available in Conjur policy, you can create a policy file `my-app.yml` that will add the secrets to policy. The `my-app` Policy can also create a Group that is entitled to fetch the secret values; the application Host can be added to that Group in [a later step](#update-policy) to grant it access to the secret values.
 


### PR DESCRIPTION
This PR updates the tile documentation to standardize the language around polices, hosts, etc to use the upper-case Policy, Host, User for components of Conjur policy, as is consistent with the rest of the Conjur documentation.

In addition, it updates the recommendations for tile configuration so that the Conjur identity used is a Conjur Host instead of a Conjur User, which is more consistent with the fact that the Service Broker is a machine and not a human actor.