### PR TITLE
Update docs and release notes for v1.1.2

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -70,10 +70,22 @@ The following table provides version and version-support information about Cyber
 CyberArk Conjur Service Broker for VMware Tanzu has the following requirements:
 
 + **You must have an existing Conjur instance installed.  The Conjur instance may be external to the VMware Tanzu environment. Supported versions are:**
-  * Conjur Enterprise (v4.9.12.0 and later)
+  
+  * CyberArk Dynamic Access Provider (DAP), v10.9 and later
+  * Conjur Enterprise, v4.9.12.0 and later
       * Use v4.9.17.0 or later to search for CF hosts in the Conjur UI
-  * Conjur Open Source (v1.0 and later)
-      * Hosted Conjur is a hosted version of Open Source Conjur. You can quickly get a hosted Conjur instance running for evaluation purposes. Visit the [hosted Conjur page](https://www.conjur.org/get-started/try-conjur.html) to sign up.
+  * Conjur Open Source, v1.0 and later
+      * We **strongly** recommend choosing the version of this project to use from the latest [Conjur OSS
+suite release](https://docs.conjur.org/Latest/en/Content/Overview/Conjur-OSS-Suite-Overview.html).
+Conjur maintainers perform additional testing on the suite release versions to ensure
+compatibility. When possible, upgrade your Conjur version to match the
+[latest suite release](https://docs.conjur.org/Latest/en/Content/ReleaseNotes/ConjurOSS-suite-RN.htm);
+when using integrations, choose the latest suite release that matches your Conjur version. For any
+questions, please contact us on [Discourse](https://discuss.cyberarkcommons.org/c/conjur/5).
+
++ If you are pushing multiple buildpacks using the Cloud Foundry CLI, 
+  ensure that your Cloud Foundry CLI version is greater than `6.38`. See 
+  the [Cloud Foundry documentation on using multiple buildpacks](https://docs.cloudfoundry.org/buildpacks/use-multiple-buildpacks.html) for more information.
 
 + **To configure the VMware Tanzu tile, you must know the following information about your Conjur installation:**
     <table class="nice">

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -5,6 +5,34 @@ owner: Partners
 
 These are release notes for CyberArk Conjur Service Broker for VMware Tanzu
 
+## <a id="ver"></a> v1.2.0
+
+**Release Date:** July 27, 2020
+
+Features in this release:
+
+* Improved service-broker validation and error handling
+  <br/>
+  - Service broker returns 404 when the org or space policy branches do not exist
+    as expected with a helpful error message, rather than returning 500.
+  - If a value is given to the `CONJUR_POLICY` environment variable, service-broker 
+    verifies that the given policy exists on the server, and provides a helpful error 
+    if it does not exist.
+
+* Expanded buildpack configuration capabilities 
+  <br/>
+  - The runtime location for `secrets.yml` can now be configured by setting the
+    `SECRETS_YAML_PATH` environment variable for the Cloud Foundry application.
+  - Buildpack supply step now scans build directory for candidate `secrets.yml` files,
+    and reports them to the buildpack deploy output during the supply phase. If unable to
+    locate any `secrets.yml` files, it will exit. 
+
+* The buildpack now properly reads only the Conjur credentials from VCAP_SERVICES. Previously, it   
+  could consume credentials for other services, if their field names exactly matched those used by 
+  Conjur (e.g. version is a very common field).
+
+Known issues in this release: No known issues.
+
 ## <a id="ver"></a> v1.1.1
 
 **Release Date:** June 21, 2019

--- a/docs-content/using/deploy-app.html.md.erb
+++ b/docs-content/using/deploy-app.html.md.erb
@@ -13,7 +13,13 @@ You can push the same application to multiple spaces. After you prepare the appl
 
 The CyberArk Conjur Service Broker for PCF uses the Summon application included in the Conjur Buildpack by default to fetch secrets from the Conjur appliance and inject the values into your application's environment.
 
-The secrets, fetched at application startup, are available only to the application process (not to users), and are gone when the process exits.  Summon requires a `secrets.yml` file in the application's root folder.
+The secrets, fetched at application startup, are available only to the application process (not to 
+users), and are gone when the process exits.  Summon requires a `secrets.yml` file in the application's root folder.
+
+If your application requires the `secrets.yml` file to be placed in a non-root directory,
+the runtime location for `secrets.yml` can be configured by setting the 
+`SECRETS_YAML_PATH` environment variable for the Cloud Foundry application. You can find more
+ information on this in [Configuring the `secrets.yml` Location](#secrets-yaml-path).
 
 If your application uses another method to access secrets, such as Conjur API calls, you do not need a `secrets.yml` file.
 
@@ -210,3 +216,31 @@ to access secrets in Conjur at the org or space level, then you're done!
 
 If you plan to have Conjur secrets entitled specifically to this application, use the
 `--no-start` option to avoid starting the application before it has the privileges it needs.
+
+#### <a id="secrets-yaml-path"></a> Configuring the `secrets.yml` Location
+
+Some final buildpacks do not allow deploying the `secrets.yml` file to the application
+root directory at runtime. In this case, the runtime location of the `secrets.yml`
+file may be configured by setting the `SECRETS_YAML_PATH` environment variable to
+its relative path.
+
+This can be configured in the application's `manifest.yml`:
+
+```
+---
+applications:
+- name: my-app
+  services:
+  - conjur
+  buildpacks:
+  - conjur_buildpack
+  - php_buildpack
+  env:
+    SECRETS_YAML_PATH: lib/secrets.yml
+```
+
+Alternatively, this may be set using the Cloud Foundry CLI:
+```
+$ cf set-env {Application Name} SECRETS_YAML_PATH {Relative Path to secrets.yml}
+$ cf restage {Application Name}
+```


### PR DESCRIPTION
- Added upgrade note and readme note specifying minimum CF CLI version for multiple buildpacks

- Added deployment note for using an alternative `secrets.yml` path or filename

- Updated release notes for features added to service broker and build pack since last tile release