### PR TITLE
Update release-notes.html.md.erb

### DIFF
--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -37,7 +37,12 @@ Fixed issues in this release:
     We recommend all users update their buildpack version to at least v2.1.5;
     v2.1.6 is included in this tile release.
 
-Known issues in this release: No known issues.
+Known issues in this release:
+
+* Service Broker fails to install if using older versions of Ruby Buildpack
+  - When using Ruby Buildpack version 1.8.15 or older, the service broker will fail to install because the Ruby
+    version will default to 2.4.x.
+    [cyberark/conjur-service-broker#229](https://github.com/cyberark/conjur-service-broker/issues/229)
 
 ## <a id="ver"></a> v1.2.0
 


### PR DESCRIPTION
### What does this PR do?
Adds a note to the 1.2.1 release about a known issue when using older Ruby buildpacks with this version. We will fix this in the next release.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation
