### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/docs-content/using/deploy-app.html.md.erb
+++ b/docs-content/using/deploy-app.html.md.erb
@@ -211,7 +211,7 @@ Target your desired orgs and spaces and push the application and its associated 
 
 <pre class='term'>cf push ...</pre>
 
-If you're using Conjur EE v5+ or Conjur OSS v1+ and you're entitling your applications
+If you're using Conjur EE v5+ or Conjur Open Source v1+ and you're entitling your applications
 to access secrets in Conjur at the org or space level, then you're done!
 
 If you plan to have Conjur secrets entitled specifically to this application, use the


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
