### PR TITLE
Indicate support for Tanzu App Service 2.12

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -53,7 +53,7 @@ The following table provides version and version-support information about Cyber
     </tr>
     <tr>
         <td>Compatible Tanzu Application Service version(s)</td>
-        <td>v2.7.x, v2.8.x, v2.9.x, v2.10.x, and v2.11.x</td>
+        <td>v2.7.x, v2.8.x, v2.9.x, v2.10.x, v2.11.x, and v2.12.x</td>
     </tr>
     <tr>
         <td>BOSH stemcell version</td>


### PR DESCRIPTION
From [ONYX-13905](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-13905):

We have tested the service broker + tile on Tanzu 2.12 and confirmed that it works. We should update the "Compatible Tanzu Application Service version(s)" table row in the Conjur Service Broker docs. The source for these docs and the release process can be found in the cyberark/docs-cyberark-conjur-service-broker repository.